### PR TITLE
adds the loop through store views (usually language versions)

### DIFF
--- a/Model/CategoryIndexer.php
+++ b/Model/CategoryIndexer.php
@@ -10,6 +10,8 @@ use Magento\Catalog\Model\ResourceModel\Category\Collection as CategoryCollectio
 use Magento\CatalogUrlRewrite\Model\CategoryUrlRewriteGenerator;
 use Magento\UrlRewrite\Model\UrlPersistInterface;
 
+use Magento\Store\Model\StoreManagerInterface;
+
 /**
  * IndexerUrlRewrite category indexer model
  */
@@ -24,7 +26,11 @@ class CategoryIndexer extends AbstractIndexer
      * @var \Magento\CatalogUrlRewrite\Model\CategoryUrlRewriteGenerator
      */
     protected $_categoryUrlRewriteGenerator;
-        
+
+
+
+    protected $_storeManager;
+
     /**
      * @param \Magento\Catalog\Model\ResourceModel\Category\Collection $categoryCollection
      * @param \Magento\Magento\CatalogUrlRewrite\Model\CategoryUrlRewriteGenerator $categoryUrlRewriteGenerator
@@ -33,10 +39,12 @@ class CategoryIndexer extends AbstractIndexer
     public function __construct(
         CategoryCollection $categoryCollection,
         CategoryUrlRewriteGenerator $categoryUrlRewriteGenerator,        
-        UrlPersistInterface $urlPersist
+        UrlPersistInterface $urlPersist,
+        StoreManagerInterface $storeManager
     ) {
         $this->_categoryCollection = $categoryCollection;
-        $this->_categoryUrlRewriteGenerator = $categoryUrlRewriteGenerator;   
+        $this->_categoryUrlRewriteGenerator = $categoryUrlRewriteGenerator;
+        $this->_storeManager  = $storeManager;
         parent::__construct($urlPersist);
     }
     	
@@ -48,10 +56,11 @@ class CategoryIndexer extends AbstractIndexer
      */
 	protected function getEntityCollection($storeId)
 	{
+		$this->_categoryCollection->clear();
 		$this->_categoryCollection->setStoreId($storeId)
 			->addAttributeToSelect(['url_path', 'url_key'])
 			->addAttributeToFilter('level', array('gt' => 1));
-			
+
 		return $this->_categoryCollection;
 	}
     

--- a/Model/CmsPageIndexer.php
+++ b/Model/CmsPageIndexer.php
@@ -10,6 +10,8 @@ use Magento\Cms\Model\ResourceModel\Page\Collection as CmsPageCollection;
 use Magento\CmsUrlRewrite\Model\CmsPageUrlRewriteGenerator;
 use Magento\UrlRewrite\Model\UrlPersistInterface;
 
+use Magento\Store\Model\StoreManagerInterface;
+
 /**
  * IndexerUrlRewrite cms page indexer model
  */
@@ -23,8 +25,10 @@ class CmsPageIndexer extends AbstractIndexer
     /**
      * @var \Magento\CmsUrlRewrite\Model\CmsPageUrlRewriteGenerator
      */
-    protected $_cmsPageUrlRewriteGenerator;  
-        
+    protected $_cmsPageUrlRewriteGenerator;
+
+    protected $_storeManager;
+
     /**
      * @param \Magento\Cms\Model\ResourceModel\Page\Collection $cmsPageCollection
      * @param \Magento\CmsUrlRewrite\Model\CmsPageUrlRewriteGenerator $cmsPageUrlRewriteGenerator
@@ -33,10 +37,12 @@ class CmsPageIndexer extends AbstractIndexer
     public function __construct(
         CmsPageCollection $cmsPageCollection,
         CmsPageUrlRewriteGenerator $cmsPageUrlRewriteGenerator,        
-        UrlPersistInterface $urlPersist
+        UrlPersistInterface $urlPersist,
+        StoreManagerInterface $storeManager
     ) {
         $this->_cmsPageCollection = $cmsPageCollection;
-        $this->_cmsPageUrlRewriteGenerator = $cmsPageUrlRewriteGenerator;        
+        $this->_cmsPageUrlRewriteGenerator = $cmsPageUrlRewriteGenerator;
+        $this->_storeManager  = $storeManager;
         parent::__construct($urlPersist);
     }
     	

--- a/Model/ProductIndexer.php
+++ b/Model/ProductIndexer.php
@@ -10,6 +10,8 @@ use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
 use Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator;
 use Magento\UrlRewrite\Model\UrlPersistInterface;
 
+use Magento\Store\Model\StoreManagerInterface;
+
 /**
  * IndexerUrlRewrite product indexer model
  */
@@ -24,7 +26,8 @@ class ProductIndexer extends AbstractIndexer
      * @var \Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator
      */
     protected $_productUrlRewriteGenerator;
-        
+
+    protected $_storeManager;
     /**
      * @param \Magento\Catalog\Model\ResourceModel\Product\Collection $productCollection
      * @param \Magento\CatalogUrlRewrite\Model\ProductUrlRewriteGenerator $productUrlRewriteGenerator
@@ -33,10 +36,12 @@ class ProductIndexer extends AbstractIndexer
     public function __construct(
         ProductCollection $productCollection,
         ProductUrlRewriteGenerator $productUrlRewriteGenerator,      
-        UrlPersistInterface $urlPersist
+        UrlPersistInterface $urlPersist,
+        StoreManagerInterface $storeManager
     ) {
         $this->_productCollection = $productCollection;
-        $this->_productUrlRewriteGenerator = $productUrlRewriteGenerator;       
+        $this->_productUrlRewriteGenerator = $productUrlRewriteGenerator;
+        $this->_storeManager  = $storeManager;
         parent::__construct($urlPersist);
     }
     	
@@ -48,6 +53,7 @@ class ProductIndexer extends AbstractIndexer
      */
 	protected function getEntityCollection($storeId)
 	{
+		$this->_productCollection->clear();
 		$this->_productCollection->setStoreId($storeId)
 			->addAttributeToSelect(['url_path', 'url_key']);
 			


### PR DESCRIPTION
Usually language version's split happens at the store view level thus different url keys would generate different url paths. E.g. **men's** in English and **hommes** in French in category names would result in variety of product paths like:
- hommes/bas-bridgedale
- mens/bridgedale-socks