### PR TITLE
Change private/protected to public

### DIFF
--- a/Model/AbstractIndexer.php
+++ b/Model/AbstractIndexer.php
@@ -20,21 +20,21 @@ abstract class AbstractIndexer implements IndexerActionInterface, MviewActionInt
      *
      * @var \Magento\UrlRewrite\Model\UrlPersistInterface
      */
-    private $urlPersist;
+    public $urlPersist;
 
     /**
      * Store manager
      *
      * @var \Magento\Store\Model\StoreManagerInterface
      */
-    private $storeManager;
+    public $storeManager;
 
     /**
      * Logger
      *
      * @var \Psr\Log\LoggerInterface
      */
-    private $logger;
+    public $logger;
 
     /**
      * Initialize Indexer
@@ -56,14 +56,14 @@ abstract class AbstractIndexer implements IndexerActionInterface, MviewActionInt
      * @param integer[] $ids
      * @return \Magento\Framework\Data\Collection\AbstractDb
      */
-    abstract protected function getEntityCollection($storeId, array $ids = []);
+    abstract public function getEntityCollection($storeId, array $ids = []);
 
     /**
      * Retrieve entity type
      *
      * @return string
      */
-    abstract protected function getEntityType();
+    abstract public function getEntityType();
 
     /**
      * Generate url rewrites
@@ -71,7 +71,7 @@ abstract class AbstractIndexer implements IndexerActionInterface, MviewActionInt
      * @param AbstractModel $entity
      * @return \Magento\UrlRewrite\Service\V1\Data\UrlRewrite[]
      */
-    abstract protected function generate($entity);
+    abstract public function generate($entity);
 
     /**
      * Execute indexation from store
@@ -80,7 +80,7 @@ abstract class AbstractIndexer implements IndexerActionInterface, MviewActionInt
      * @param integer[] $ids
      * @return void
      */
-    private function executeStore($storeId, array $ids = [])
+    public function executeStore($storeId, array $ids = [])
     {
         foreach ($this->getEntityCollection($storeId, $ids) as $entity) {
             $this->deleteEntity($entity->getId(), $storeId);
@@ -99,7 +99,7 @@ abstract class AbstractIndexer implements IndexerActionInterface, MviewActionInt
      * @param integer $storeId
      * @return void
      */
-    private function deleteEntity($entityId, $storeId)
+    public function deleteEntity($entityId, $storeId)
     {
         $this->urlPersist->deleteByData([
             UrlRewrite::ENTITY_ID => $entityId,

--- a/Model/CategoryIndexer.php
+++ b/Model/CategoryIndexer.php
@@ -18,14 +18,14 @@ class CategoryIndexer extends AbstractIndexer
      *
      * @var CategoryCollectionFactory
      */
-    private $categoryCollectionFactory;
+    public $categoryCollectionFactory;
 
     /**
      * UrlRewrite generator
      *
      * @var CategoryUrlRewriteGenerator
      */
-    private $urlRewriteGenerator;
+    public $urlRewriteGenerator;
 
     /**
      * Initialize indexer
@@ -54,7 +54,7 @@ class CategoryIndexer extends AbstractIndexer
      * @param integer[] $ids
      * @return \Magento\Framework\Data\Collection\AbstractDb
      */
-    protected function getEntityCollection($storeId, array $ids = [])
+    public function getEntityCollection($storeId, array $ids = [])
     {
         $collection = $this->categoryCollectionFactory->create();
         if (count($ids)) {
@@ -73,7 +73,7 @@ class CategoryIndexer extends AbstractIndexer
      *
      * @return string
      */
-    protected function getEntityType()
+    public function getEntityType()
     {
         return CategoryUrlRewriteGenerator::ENTITY_TYPE;
     }
@@ -84,7 +84,7 @@ class CategoryIndexer extends AbstractIndexer
      * @param \Magento\Catalog\Model\Category $entity
      * @return \Magento\UrlRewrite\Service\V1\Data\UrlRewrite[]
      */
-    protected function generate($entity)
+    public function generate($entity)
     {
         return $this->urlRewriteGenerator->generate($entity);
     }

--- a/Model/CmsPageIndexer.php
+++ b/Model/CmsPageIndexer.php
@@ -18,14 +18,14 @@ class CmsPageIndexer extends AbstractIndexer
      *
      * @var CmsPageCollectionFactory
      */
-    private $cmsPageCollectionFactory;
+    protected $cmsPageCollectionFactory;
 
     /**
      * UrlRewrite generator
      *
      * @var CmsPageUrlRewriteGenerator
      */
-    private $urlRewriteGenerator;
+    protected $urlRewriteGenerator;
 
     /**
      * Initialize indexer

--- a/Model/Context.php
+++ b/Model/Context.php
@@ -19,21 +19,21 @@ class Context
      *
      * @var UrlPersistInterface
      */
-    private $urlPersist;
+    public $urlPersist;
 
     /**
      * Store Manager
      *
      * @var StoreManagerInterface
      */
-    private $storeManager;
+    public $storeManager;
 
     /**
      * Logger
      *
      * @var LoggerInterface
      */
-    private $logger;
+    public $logger;
 
     /**
      * Initialize context

--- a/Model/ProductIndexer.php
+++ b/Model/ProductIndexer.php
@@ -18,14 +18,14 @@ class ProductIndexer extends AbstractIndexer
      *
      * @var ProductCollectionFactory
      */
-    private $productCollectionFactory;
+    public $productCollectionFactory;
 
     /**
      * UrlRewrite generator
      *
      * @var ProductUrlRewriteGenerator
      */
-    private $urlRewriteGenerator;
+    public $urlRewriteGenerator;
 
     /**
      * Initialize indexer
@@ -54,7 +54,7 @@ class ProductIndexer extends AbstractIndexer
      * @param integer[] $ids
      * @return \Magento\Framework\Data\Collection\AbstractDb
      */
-    protected function getEntityCollection($storeId, array $ids = [])
+    public function getEntityCollection($storeId, array $ids = [])
     {
         $collection = $this->productCollectionFactory->create();
         if (count($ids)) {
@@ -72,7 +72,7 @@ class ProductIndexer extends AbstractIndexer
      *
      * @return string
      */
-    protected function getEntityType()
+    public function getEntityType()
     {
         return ProductUrlRewriteGenerator::ENTITY_TYPE;
     }
@@ -83,7 +83,7 @@ class ProductIndexer extends AbstractIndexer
      * @param \Magento\Catalog\Model\Product $entity
      * @return \Magento\UrlRewrite\Service\V1\Data\UrlRewrite[]
      */
-    protected function generate($entity)
+    public function generate($entity)
     {
         return $this->urlRewriteGenerator->generate($entity);
     }


### PR DESCRIPTION
In the current context there is no way for anyone to make a plugin to change any of the behavior of  this module due to there is only few functions that is public. The few that can be changed with a plugin is also very much useless to make a plugin with due the the properties is set to private and therefore unusable within the plugin context.
If you instead tend to try to make a rewrite the classes you will still be facing with issue where all properties is make private as well as most of the functions. Therefor, the only way to properly rewrite any of the classes you need to copy more of less all logic from the class to a local class.

Would help a lot of you just have all functions and properties public. 