### PR TITLE
Prevent memory consumption

### DIFF
--- a/Model/AbstractIndexer.php
+++ b/Model/AbstractIndexer.php
@@ -83,6 +83,14 @@ abstract class AbstractIndexer implements IndexerActionInterface, MviewActionInt
             } catch (\Exception $e) {
                 $this->logger->critical($e);
             }
+
+            $r = new \ReflectionObject($entity);
+            $p = $r->getProperty('categoryCollection');
+            $p->setAccessible(true);
+            $p->setValue($entity, null);
+
+            $entity->clearInstance();
+            unset($entity);
         }
     }
 


### PR DESCRIPTION
Inside $this->generate() method there is code for assign category collection to product. When we have product collection (ie more then 50k products) and for each of them is assign category collection, the memory is consuming more then 2GB RAM.  So we need just forget category collection after generate urls for him.